### PR TITLE
Give monorail loco wireless control

### DIFF
--- a/assets/immersiverailroading/rolling_stock/locomotives/monorail_engine.json
+++ b/assets/immersiverailroading/rolling_stock/locomotives/monorail_engine.json
@@ -13,7 +13,8 @@
 		"tractive_effort_lbf": 30000,
 		"max_speed_kmh": 100,
 		"weight_kg": 22000,
-		"horn_sustained": true
+		"horn_sustained": true,
+		"radio_equipped":true
 	},
 	"passenger": {
 		"slots": 2,


### PR DESCRIPTION
![image](https://github.com/SymmetricDevs/BlackMesaTransitSystem/assets/38543604/eb416bbd-9b49-40a5-9a68-01183a7f91c5)
The questbook implies you can use wireless control but the only locomotive has it disabled. This enables it so players can automate trains using the wireless card.